### PR TITLE
[feature] Add mouse support (normal and relative mode)

### DIFF
--- a/SDL.lean
+++ b/SDL.lean
@@ -14,6 +14,13 @@ def SDL_SCANCODE_RIGHT : UInt32 := 79
 def SDL_SCANCODE_SPACE : UInt32 := 44
 def SDL_SCANCODE_ESCAPE : UInt32 := 41
 
+def SDL_MOUSEBUTTONDOWN : UInt32 := 0x401
+def SDL_MOUSEBUTTONUP : UInt32 := 0x402
+def SDL_MOUSEMOTION : UInt32 := 0x400
+def SDL_BUTTON_LEFT : UInt32 := 1
+def SDL_BUTTON_MIDDLE : UInt32 := 2
+def SDL_BUTTON_RIGHT : UInt32 := 4
+
 @[extern "sdl_init"]
 opaque init : UInt32 → IO UInt32
 
@@ -64,4 +71,27 @@ opaque renderTexture (x : Int32) (y : Int32) (w : Int32) (h : Int32) : IO Int32
 
 @[extern "sdl_render_text"]
 opaque renderText (message : String) (x : Int32) (y : Int32) (red : UInt8) (green : UInt8) (blue : UInt8) (alpha : UInt8) : IO Int32
+
+-- Mouse support
+@[extern "sdl_get_mouse_state"]
+opaque getMouseStateRaw : IO UInt64
+
+@[extern "sdl_set_relative_mouse_mode"]
+opaque setRelativeMouseMode (enabled : Bool) : IO UInt32
+
+def getMousePos : IO (Int32 × Int32) := do
+  let packed ← getMouseStateRaw
+  let x := (packed >>> 32).toUInt32.toInt32
+  let y := ((packed >>> 16) &&& 0xFFFF).toUInt32.toInt32
+  return (x, y)
+
+def isMousePressed (button : UInt32) : IO Bool := do
+  let packed ← getMouseStateRaw
+  let buttons := (packed &&& 0xFFFF).toUInt32
+  return (buttons &&& button) != 0
+
+def isLeftMousePressed : IO Bool := isMousePressed SDL_BUTTON_LEFT
+def isRightMousePressed : IO Bool := isMousePressed SDL_BUTTON_RIGHT
+def isMiddleMousePressed : IO Bool := isMousePressed SDL_BUTTON_MIDDLE
+
 end SDL

--- a/TestApp.lean
+++ b/TestApp.lean
@@ -66,6 +66,15 @@ partial def gameLoop (engineState : IO.Ref EngineState) : IO Unit := do
   if eventType == SDL.SDL_QUIT || (← isKeyDown .Escape) then
     engineState.modify (fun s => { s with running := false })
 
+  if eventType == SDL.SDL_MOUSEBUTTONDOWN then
+    let (mouseX, mouseY) ← SDL.getMousePos
+    if ← SDL.isLeftMousePressed then
+      IO.println s!"Left click at ({mouseX}, {mouseY})"
+    if ← SDL.isRightMousePressed then
+      IO.println s!"Right click at ({mouseX}, {mouseY})"
+    if ← SDL.isMiddleMousePressed then
+      IO.println s!"Middle click at ({mouseX}, {mouseY})"
+
   let state ← engineState.get
   if state.running then
     renderScene state

--- a/c/sdl.c
+++ b/c/sdl.c
@@ -178,3 +178,35 @@ lean_obj_res sdl_render_texture(uint32_t dst_x, uint32_t dst_y, uint32_t dst_hei
 
     return lean_io_result_mk_ok(lean_box_uint32(SDL_RenderTexture(g_renderer, g_texture, NULL, &dst_rect)));
 }
+
+// Mouse support (caching avoids redundant SDL calls within the same frame)
+static struct {
+    float x, y;
+    uint32_t buttons;
+    bool relative_mode;
+    uint32_t last_frame_tick;
+} mouse_cache = {0, 0, 0, false, 0};
+
+lean_obj_res sdl_get_mouse_state(lean_obj_arg w) {
+    uint32_t current_tick = SDL_GetTicks();
+    if (mouse_cache.last_frame_tick != current_tick) {
+        if (mouse_cache.relative_mode) {
+            mouse_cache.buttons = SDL_GetRelativeMouseState(&mouse_cache.x, &mouse_cache.y);
+        } else {
+            mouse_cache.buttons = SDL_GetMouseState(&mouse_cache.x, &mouse_cache.y);
+        }
+        mouse_cache.last_frame_tick = current_tick;
+    }
+
+    uint64_t packed = ((uint64_t)(uint32_t)(int32_t)mouse_cache.x << 32) | 
+                      ((uint64_t)(uint32_t)(int32_t)mouse_cache.y << 16) |
+                      (uint64_t)mouse_cache.buttons;
+    return lean_io_result_mk_ok(lean_box_uint64(packed));
+}
+
+lean_obj_res sdl_set_relative_mouse_mode(bool enabled, lean_obj_arg w) {
+    int32_t result = SDL_SetWindowRelativeMouseMode(g_window, enabled);
+    mouse_cache.relative_mode = enabled;
+    mouse_cache.last_frame_tick = 0; // Force refresh
+    return lean_io_result_mk_ok(lean_box_uint32(result));
+}


### PR DESCRIPTION
This PR adds mouse support. Relative mode is used for camera control using dx and dy (e.g. FPS).
It also provides some convenience functions to check, which mouse button is pressed.
Mouse position is cached, such that we only have to call SDL_GetMouseState once per frame. However, we have to call SDL_GetTicks for each request. The assumption was that this call is cheaper than getting mouse state. 